### PR TITLE
explicit check for bot before adding kspree

### DIFF
--- a/killingspree.py
+++ b/killingspree.py
@@ -231,7 +231,9 @@ class killingspree(minqlx.Plugin):
                     else:
                         if self.kspree[id] > self.longest_spree['ks']:
                             self.longest_spree = {'name': v_name, 'ks': self.kspree[id]}
-                self.kspree[id] = 0
+                            
+                if id != "0":
+                    self.kspree[id] = 0
 
             def checkDSpree(id, name):
                 if self.dspree[id] % 5 == 0:
@@ -349,12 +351,10 @@ class killingspree(minqlx.Plugin):
             if data['KILLER'] is not None and not data['TEAMKILL']: #normal kill
                 k_id = data['KILLER']['STEAM_ID']
                 k_name = data['KILLER']['NAME']
-                try:
+                if k_id != "0":
                     self.kspree[k_id] = self.kspree[k_id] + 1
                     checkKSpree(k_id, k_name)
                     checkMultiKill(k_id, k_name)
-                except: #if killed by bot (k_id = 0 is not in self.kspree)
-                    pass
                 checkKSpreeEnd(v_id, v_name, k_name, True)
                 if k_id in self.dspree:
                     if self.dspree[k_id] != 0:


### PR DESCRIPTION
Depending on an exception at line 354 wasn't working because id "0" did have a kspree -- it was being set to 0 at the end of checkKSpreeEnd.   It's also being set somewhere else -- sometimes the bots would get on runs and for some reason earn records.  I haven't had the time to figure out under what conditions this happens, so it seems easiest to just check the id before treating the bots as flesh.
