### PR TITLE
Fix redis-py 3.0+ compatibility in warn.py

### DIFF
--- a/warn.py
+++ b/warn.py
@@ -3,6 +3,7 @@
 # !warn <id> <reason>
 # !unwarn <id> <warnings to remove>
 # !warned (to list all warned players)
+# Updated 2025-11-24: Fixed redis-py 3.0+ compatibility (zadd syntax)
 
 import minqlx
 import time
@@ -86,7 +87,8 @@ class warn(minqlx.Plugin):
         base_key = PLAYER_KEY.format(ident) + ":warnings"
         warn_id = self.db.zcard(base_key)
         db = self.db.pipeline()
-        db.zadd(base_key, time.time() + td.total_seconds(), warn_id)
+        # FIXED: Changed zadd syntax for redis-py 3.0+ compatibility
+        db.zadd(base_key, {warn_id: time.time() + td.total_seconds()})
         db.incr(PLAYER_KEY.format(ident) + ":warnings:strikes")
         warn = {"expires": expires, "reason": reason, "issued": now, "issued_by": player.steam_id}
         db.hmset(base_key + ":{}".format(warn_id), warn)


### PR DESCRIPTION
## Problem
   The `warn.py` plugin crashes with modern redis-py (3.0+) versions due to changed `zadd()` API.
   
   ## Error
```
   AttributeError: 'float' object has no attribute 'items'
```
   
   ## Solution
   Updated `zadd()` call on line 89 to use dictionary mapping syntax required by redis-py 3.0+:
   
   **Before:**
```python
   db.zadd(base_key, time.time() + td.total_seconds(), warn_id)
```
   
   **After:**
```python
   db.zadd(base_key, {warn_id: time.time() + td.total_seconds()})
```
   
   ## Testing
   - Tested on Ubuntu 24.04 with Python 3.12 and redis-py 5.x
   - All commands work correctly: `!warn`, `!unwarn`, `!warned`
   - Existing warnings preserved and functional
   
   ## References
   - redis-py changelog: https://github.com/redis/redis-py/blob/master/CHANGES
   - zadd() documentation: https://redis.io/commands/zadd/